### PR TITLE
Don't catch or ignore Throwables

### DIFF
--- a/bravo-test-utils/src/main/java/com/king/bravo/testing/BravoTestPipeline.java
+++ b/bravo-test-utils/src/main/java/com/king/bravo/testing/BravoTestPipeline.java
@@ -17,15 +17,13 @@
  */
 package com.king.bravo.testing;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Function;
-
+import com.king.bravo.testing.actions.CancelJob;
+import com.king.bravo.testing.actions.NextWatermark;
+import com.king.bravo.testing.actions.Process;
+import com.king.bravo.testing.actions.Sleep;
+import com.king.bravo.testing.actions.TestPipelineSource;
+import com.king.bravo.testing.actions.TriggerFailure;
+import com.king.bravo.testing.actions.TriggerSavepoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -55,13 +53,14 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.king.bravo.testing.actions.CancelJob;
-import com.king.bravo.testing.actions.NextWatermark;
-import com.king.bravo.testing.actions.Process;
-import com.king.bravo.testing.actions.Sleep;
-import com.king.bravo.testing.actions.TestPipelineSource;
-import com.king.bravo.testing.actions.TriggerFailure;
-import com.king.bravo.testing.actions.TriggerSavepoint;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
 
 public abstract class BravoTestPipeline extends TestLogger implements Serializable {
 	private static final long serialVersionUID = 1L;
@@ -236,7 +235,7 @@ public abstract class BravoTestPipeline extends TestLogger implements Serializab
 		sleep(time.toMilliseconds());
 	}
 
-	public static Savepoint loadSavepoint(String checkpointPointer) throws IOException {
+	public static Savepoint loadSavepoint(String checkpointPointer) {
 		try {
 			Method resolveCheckpointPointer = AbstractFsCheckpointStorage.class.getDeclaredMethod(
 					"resolveCheckpointPointer",
@@ -247,8 +246,8 @@ public abstract class BravoTestPipeline extends TestLogger implements Serializab
 
 			return Checkpoints.loadCheckpointMetadata(new DataInputStream(loc.getMetadataHandle().openInputStream()),
 					BravoTestPipeline.class.getClassLoader());
-		} catch (Throwable t) {
-			throw new RuntimeException(t);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
 		}
 
 	}

--- a/bravo/src/main/java/com/king/bravo/utils/StateMetadataUtils.java
+++ b/bravo/src/main/java/com/king/bravo/utils/StateMetadataUtils.java
@@ -17,17 +17,6 @@
  */
 package com.king.bravo.utils;
 
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import org.apache.flink.api.common.typeutils.CompositeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -51,6 +40,17 @@ import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.CommonSerializerKeys;
 
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 public class StateMetadataUtils {
 
 	/**
@@ -67,8 +67,8 @@ public class StateMetadataUtils {
 
 			return Checkpoints.loadCheckpointMetadata(new DataInputStream(loc.getMetadataHandle().openInputStream()),
 					StateMetadataUtils.class.getClassLoader());
-		} catch (Throwable t) {
-			throw new RuntimeException(t);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
 		}
 
 	}
@@ -134,7 +134,7 @@ public class StateMetadataUtils {
 			} else {
 				return Optional.of(getKeyedBackendSerializationProxy((StreamStateHandle) firstHandle));
 			}
-		} catch (Throwable t) {
+		} catch (Exception e) {
 			return Optional.empty();
 		}
 	}


### PR DESCRIPTION
I had this error on my job:

	java.lang.NoSuchMethodError: org.apache.flink.runtime.state.KeyedBackendSerializationProxy.<init>(Ljava/lang/ClassLoader;)V

I used debugger to find it. The error was silently ignored by `StateMetadataUtils#getKeyedBackendSerializationProxy` which returned `Optional.empty()` instead.

The exception that was eventually thrown was misleading and wrong:

```
Exception in thread "main" java.lang.IllegalStateException: Cannot read state of a stateless operator.
	at com.king.bravo.reader.OperatorStateReader.lambda$readKeyedStates$6(OperatorStateReader.java:101)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at com.king.bravo.reader.OperatorStateReader.readKeyedStates(OperatorStateReader.java:101)
```

`./gradlew test` passed with these changes.