### PR TITLE
Rename: reducer state -> window state

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ KeyedStateReader.forValueStateValues(...)
 KeyedStateReader.forMapStateEntries(...)
 KeyedStateReader.forListStates(...)
 KeyedStateReader.forMapStateValues(...)
-KeyedStateReader.forReducerStateValues(...)
+KeyedStateReader.forWindowStateValues(...)
 ```
 
 For more complete code examples on the usage of the specific readers please look at some of the test cases, they are actually quite nice:

--- a/bravo/src/main/java/com/king/bravo/reader/KeyedStateReader.java
+++ b/bravo/src/main/java/com/king/bravo/reader/KeyedStateReader.java
@@ -45,7 +45,7 @@ public abstract class KeyedStateReader<K, V, O> extends RichFlatMapFunction<Keye
 
 	// The name "window-contents" appears as a plain string in many places in Flink source code. There is no constant
 	// that we could refer from Flink.
-	private static final String REDUCER_STATE_NAME = "window-contents";
+	private static final String WINDOW_STATE_NAME = "window-contents";
 
 	protected final String stateName;
 
@@ -256,20 +256,20 @@ public abstract class KeyedStateReader<K, V, O> extends RichFlatMapFunction<Keye
 	}
 
     /**
-     * Create a reader for state values of a reduce operator. The provided type info will be used to deserialize the
+     * Create a reader for state values of a window operator. The provided type info will be used to deserialize the
      * state (allowing possible optimizations)
      */
-	public static <K, V> KeyedStateReader<K, V, V> forReducerStateValues(TypeInformation<V> outValueType) {
-		return new ValueStateValueReader(REDUCER_STATE_NAME, outValueType);
+	public static <K, V> KeyedStateReader<K, V, V> forWindowStateValues(TypeInformation<V> outValueType) {
+		return new ValueStateValueReader(WINDOW_STATE_NAME, outValueType);
 	}
 
     /**
-     * Create a reader for state key-value pairs of a reduce operator. The provided type info will be used to
+     * Create a reader for state key-value pairs of a window operator. The provided type info will be used to
      * deserialize the state (allowing possible optimizations)
      */
-	public static <K, V> KeyedStateReader<K, V, Tuple2<K, V>> forReducerStateKVPairs(
+	public static <K, V> KeyedStateReader<K, V, Tuple2<K, V>> forWindowStateKVPairs(
 			TypeInformation<K> outKeyType, TypeInformation<V> outValueType) {
-		return new ValueStateKVReader(REDUCER_STATE_NAME, outKeyType, outValueType);
+		return new ValueStateKVReader(WINDOW_STATE_NAME, outKeyType, outValueType);
 	}
 
 	public String getStateName() {

--- a/bravo/src/test/java/com/king/bravo/WindowStateReadingTest.java
+++ b/bravo/src/test/java/com/king/bravo/WindowStateReadingTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.api.java.ExecutionEnvironment.createLocalEnvironment;
 import static org.junit.Assert.assertEquals;
 
-public class ReducerStateReadingTest extends BravoTestPipeline {
+public class WindowStateReadingTest extends BravoTestPipeline {
 
     private static final long serialVersionUID = 1L;
     private static final String REDUCER_UID = "test-reducer";

--- a/bravo/src/test/java/com/king/bravo/WindowStateReadingTest.java
+++ b/bravo/src/test/java/com/king/bravo/WindowStateReadingTest.java
@@ -29,20 +29,20 @@ public class WindowStateReadingTest extends BravoTestPipeline {
     private static final MapTypeInfo<String, String> MAP_TYPE_INFO = new MapTypeInfo<>(String.class, String.class);
 
     @Test
-    public void readReducerState() throws Exception {
+    public void readWindowState() throws Exception {
         Arrays.asList("1,1", "2,3", "1,2", "1,1").stream().forEach(this::process);
         sleep(1000);
         cancelJob();
         runTestPipeline(this::constructTestPipeline);
         OperatorStateReader reader = new OperatorStateReader(createLocalEnvironment(), getLastCheckpoint(),
                 REDUCER_UID);
-        assertReadReducerStateValues(reader);
-        assertReadReducerStateKVPairs(reader);
+        assertReadWindowStateValues(reader);
+        assertReadWindowStateKVPairs(reader);
     }
 
-    private void assertReadReducerStateValues(OperatorStateReader reader) throws Exception {
+    private void assertReadWindowStateValues(OperatorStateReader reader) throws Exception {
         List<Map<String, String>> mapValues = reader.readKeyedStates(KeyedStateReader
-                .forReducerStateValues(MAP_TYPE_INFO)).collect();
+                .forWindowStateValues(MAP_TYPE_INFO)).collect();
 
         assertEquals(
                 ImmutableSet.of(
@@ -51,9 +51,9 @@ public class WindowStateReadingTest extends BravoTestPipeline {
                 ), ImmutableSet.copyOf(mapValues));
     }
 
-    private void assertReadReducerStateKVPairs(OperatorStateReader reader) throws Exception {
+    private void assertReadWindowStateKVPairs(OperatorStateReader reader) throws Exception {
         List<Tuple2<String, Map<String, String>>> mapKeysAndValues = reader.readKeyedStates(KeyedStateReader
-                .forReducerStateKVPairs(BasicTypeInfo.STRING_TYPE_INFO, MAP_TYPE_INFO)).collect();
+                .forWindowStateKVPairs(BasicTypeInfo.STRING_TYPE_INFO, MAP_TYPE_INFO)).collect();
 
         assertEquals(
                 ImmutableMap.of(


### PR DESCRIPTION
The correct term to use on this level is "window state" instead of "reducer state", because these features are not specific to reducer – they should work the same for other window operators.